### PR TITLE
post-submission-updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ venv/
 .Rproj.user/
 
 release*/*
-report/*
+report/old/*
+report/*.png
 
 manuscript/*.docx
 manuscript/*.png

--- a/analysis/model/cox.R
+++ b/analysis/model/cox.R
@@ -184,7 +184,7 @@ coxcontrast <- function(data, adj = FALSE, cuts=NULL){
     select(-n_events, -min_events) %>%
     group_by(!!subgroup_sym) %>%
     nest() %>%
-    # add strata(period_id) to cox_formula if period_id has more than one distinct values
+    # add :period_id to cox_formula if period_id has more than one distinct values
     mutate(cox_formula = map(data, ~{
       if_else(
         n_distinct(.x$period_id) == 1,

--- a/analysis/variables_jcvi.py
+++ b/analysis/variables_jcvi.py
@@ -73,8 +73,8 @@ def generate_jcvi_variables(index_date):
 
     sev_obesity = patients.satisfying(
       """
-      (sev_obesity_date > bmi_date) OR
-      (bmi_value1 >= 40)
+      sev_obesity_date > bmi_date OR
+      bmi_value1 >= 40
       """,
 
       bmi_stage_date=patients.with_these_clinical_events(

--- a/analysis/variables_jcvi.py
+++ b/analysis/variables_jcvi.py
@@ -73,8 +73,8 @@ def generate_jcvi_variables(index_date):
 
     sev_obesity = patients.satisfying(
       """
-      sev_obesity_date > bmi_date OR
-      bmi_value1 >= 40
+      (sev_obesity_date > bmi_date) OR
+      (bmi_value1 >= 40)
       """,
 
       bmi_stage_date=patients.with_these_clinical_events(
@@ -164,7 +164,8 @@ def generate_jcvi_variables(index_date):
   chronic_kidney_disease=patients.satisfying(
     """
     ckd OR
-    (ckd15_date AND ckd35_date >= ckd15_date)
+    ((ckd35_date AND ckd15_date) AND (ckd35_date >= ckd15_date)) OR
+    (ckd35_date AND NOT ckd15_date)
     """,
 
     # Chronic kidney disease codes - all stages

--- a/analysis/variables_pre.py
+++ b/analysis/variables_pre.py
@@ -57,13 +57,13 @@ def generate_pre_variables(index_date):
   ),
   discharged_unplanned_0_date=patients.admitted_to_hospital(
     returning="date_discharged",
-    on_or_after="admitted_unplanned_0_date",
+    on_or_before=f"{index_date} - 1 day",
     # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
     # see https://docs.opensafely.org/study-def-variables/#sus for more info
     with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
     with_patient_classification = ["1"], # ordinary admissions only
     date_format="YYYY-MM-DD",
-    find_first_match_in_period=True,
+    find_last_match_in_period=True,
   ), 
 
   # planned hospital admission
@@ -79,13 +79,13 @@ def generate_pre_variables(index_date):
   ),
   discharged_planned_0_date=patients.admitted_to_hospital(
     returning="date_discharged",
-    on_or_after="admitted_planned_0_date",
+    on_or_before=f"{index_date} - 1 day",
     # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
     # see https://docs.opensafely.org/study-def-variables/#sus for more info
     with_admission_method=["11", "12", "13", "81"],
     with_patient_classification = ["1"], # ordinary admissions only
     date_format="YYYY-MM-DD",
-    find_first_match_in_period=True
+    find_last_match_in_period=True
   ), 
   
   # Positive covid admission prior to study start date

--- a/analysis/variables_pre.py
+++ b/analysis/variables_pre.py
@@ -57,13 +57,13 @@ def generate_pre_variables(index_date):
   ),
   discharged_unplanned_0_date=patients.admitted_to_hospital(
     returning="date_discharged",
-    on_or_before=f"{index_date} - 1 day",
+    on_or_after="admitted_unplanned_0_date",
     # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
     # see https://docs.opensafely.org/study-def-variables/#sus for more info
     with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
     with_patient_classification = ["1"], # ordinary admissions only
     date_format="YYYY-MM-DD",
-    find_last_match_in_period=True,
+    find_first_match_in_period=True,
   ), 
 
   # planned hospital admission
@@ -79,13 +79,13 @@ def generate_pre_variables(index_date):
   ),
   discharged_planned_0_date=patients.admitted_to_hospital(
     returning="date_discharged",
-    on_or_before=f"{index_date} - 1 day",
+    on_or_after="admitted_planned_0_date",
     # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
     # see https://docs.opensafely.org/study-def-variables/#sus for more info
     with_admission_method=["11", "12", "13", "81"],
     with_patient_classification = ["1"], # ordinary admissions only
     date_format="YYYY-MM-DD",
-    find_last_match_in_period=True
+    find_first_match_in_period=True
   ), 
   
   # Positive covid admission prior to study start date

--- a/manuscript/functions.R
+++ b/manuscript/functions.R
@@ -165,7 +165,7 @@ km_plot <- function(.data, colour_var="variant_descr",
     ) +
     coord_cartesian(xlim=c(0, NA)) +
     labs(
-      x="Days since third dose",
+      x="Days since booster dose",
       y="Cumulative incidence (x 1,000)"
     ) +
     guides(nrow = 2) +
@@ -230,7 +230,7 @@ hr_plot <- function(.data, colour_var="variant_descr") {
     ) +
     facet_grid(rows = vars(outcome_descr), switch = "y", scales = "free", space = "free_x") +
     scale_x_continuous(
-      name = "Days since third dose",
+      name = "Days since booster dose",
       breaks = postbaselinecuts,
       limits = c(min(postbaselinecuts), max(postbaselinecuts)),
       expand = expansion(

--- a/report/target-trials.R
+++ b/report/target-trials.R
@@ -1,0 +1,182 @@
+library(tidyverse)
+library(here)
+
+source(here("analysis", "design.R"))
+
+
+## cumulative incidence curves
+km_contrasts_rounded <- read_csv(
+  here("release20230207", "km_contrasts_rounded.csv")
+)
+
+km_plot_data <-
+  km_contrasts_rounded %>%
+  filter(
+    outcome == "covidadmitted",
+    variant_option == "ignore",
+    subgroup == "all",
+    filename == "daily"
+    ) %>%
+  select(
+    time = period_end,
+    matches(c("^risk_\\d", "^risk.ll_\\d", "^risk.ul_\\d"))
+  ) %>%
+  pivot_longer(
+    cols = starts_with("risk"),
+    names_pattern = "(.*)_(.)",
+    names_to = c(".value", "group")
+    ) %>%
+    group_by(group) %>%
+    group_modify(
+      ~add_row(
+        .x,
+        time=0,
+        risk=0,
+        risk.ll=0,
+        risk.ul=0,
+        .before=0
+      )
+    ) %>%
+    # use lagtime for confident intervals, use default=0 as confidence interval = c(0,0) at time 0
+    # avoids error about removing x rows with missing values
+    mutate(lagtime = lag(time, default=0)) %>%
+    ungroup() %>%
+  mutate(across(group, ~factor(.x, levels = as.character(0:1), labels = c("Unboosted", "Boosted")))) %>%
+  # risk per 1000
+  mutate(across(starts_with("risk"), ~ 1000*.x))
+
+leg_title <- guide_legend(NULL)
+
+p1 <- km_plot_data %>%
+  ggplot(aes(
+    group=group,
+    colour=group,
+    linetype=group,
+    fill=group
+  )) +
+  geom_step(
+    aes(x=time, y=risk),
+    direction="vh"
+  ) +
+  geom_rect(
+    aes(xmin=lagtime, xmax=time, ymin=risk.ll, ymax=risk.ul),
+    alpha=0.1, colour="transparent"
+  ) +
+  scale_x_continuous(breaks = postbaselinecuts) +
+  scale_linetype_manual(values = c("Unboosted" = "dashed", "Boosted" = "solid")) +
+  guides(colour = leg_title, linetype = leg_title, fill = leg_title) +
+  labs(
+    x = "Days since trial start",
+    y = "Cumulative incidence per 1,000",
+    subtitle = "COVID-19 hospitalisation"
+  ) +
+  theme_bw() +
+  theme(
+    axis.title.x = element_text(margin = margin(t=10)),
+    axis.title.y = element_text(margin = margin(r=10)),
+    legend.position = c(0.2,0.8)
+  )
+
+ggsave(
+  plot = p1,
+  filename = here("report", "km_full.png"),
+  height = 14, width = 14, units = "cm"
+)
+
+p2 <- p1 + 
+  scale_x_continuous(breaks = seq(0,14,2)) +
+  coord_cartesian(xlim = c(0,14), ylim = c(0,0.5)) 
+  
+ggsave(
+  plot = p2,
+  filename = here("report", "km_28.png"),
+  height = 14, width = 14, units = "cm"
+)
+
+## hazard ratios
+cox_contrasts_rounded <- read_csv(
+  here("release20230207", "cox_contrasts_rounded.csv")
+)
+
+cox_plot_data <-
+  cox_contrasts_rounded %>%
+  filter(
+    outcome == "covidadmitted",
+    variant_option == "ignore",
+    subgroup == "all",
+    model == "cox_adj",
+    str_detect(term, "^treated"),
+    filename == "cuts"
+  ) %>%
+  mutate(
+    period = str_extract(term, "\\d+-\\d+"),
+    period_start = as.integer(str_extract(period, "^\\d+")),
+    period_end = as.integer(str_extract(period, "\\d+$")),
+    midpoint = period_start + (period_end-period_start)/2
+    )
+
+position_dodge_val <- 0.8
+
+primary_vax_y1 <- list(breaks = c(0.15, 0.25, 0.5, 0.75, 1), limits = c(0.15, 1))
+primary_vax_y2 <- list(breaks = c(0, 0.25, 0.5, 0.75, 0.85))
+
+formatpercent100 <- function(x,accuracy) {
+  formatx <- scales::label_percent(accuracy)(x)
+  
+  if_else(
+    formatx==scales::label_percent(accuracy)(1),
+    paste0(">",scales::label_percent(1)((100-accuracy)/100)),
+    formatx
+  )
+}
+
+x_labels <- cox_plot_data %>%
+  distinct(midpoint, period) %>%
+  arrange(midpoint)
+
+p3 <- cox_plot_data %>%
+  ggplot(aes(x = midpoint)) +
+  geom_hline(aes(yintercept=1), colour='grey') +
+  geom_linerange(
+    aes(ymin = coxhr.ll, ymax = coxhr.ul),
+    position = position_dodge(width = position_dodge_val)
+  ) +
+  geom_point(
+    aes(y = coxhr),
+    position = position_dodge(width = position_dodge_val),
+    size = 2
+  ) +
+  scale_x_continuous(
+    name = "Days since third dose",
+    breaks = x_labels$midpoint,
+    labels = x_labels$period,
+    limits = c(min(postbaselinecuts), max(postbaselinecuts)),
+    expand = expansion(add = c(0,0))
+  ) +
+  scale_y_log10(
+    name = "Adjusted hazard ratio (aHR)",
+    breaks = primary_vax_y1[["breaks"]],
+    limits = primary_vax_y1[["limits"]],
+    oob = scales::oob_keep,
+    sec.axis = sec_axis(
+      ~(1-.),
+      name="Vaccine effectiveness = 100 x (1 - aHR)",
+      breaks = primary_vax_y2[["breaks"]],
+      labels = function(x){formatpercent100(x, 1)}
+    )
+  ) +
+  labs(
+    subtitle = "COVID-19 hospitalisation"
+  ) +
+  theme_bw() +
+  theme(
+    axis.title.x = element_text(margin = margin(t=10)),
+    axis.title.y.left = element_text(margin = margin(r=10)),
+    axis.title.y.right = element_text(margin = margin(l=10))
+  )
+
+ggsave(
+  plot = p3,
+  filename = here("report", "cox_hr.png"),
+  height = 14, width = 14, units = "cm"
+)


### PR DESCRIPTION
This branch includes all updates since manuscript submission. The following files have been updated:

- [.gitignore](https://github.com/opensafely/vaccine-effectiveness-3dose/pull/20/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947)
- [analysis/model/cox.R](https://github.com/opensafely/vaccine-effectiveness-3dose/pull/20/files#diff-1ed8b34bda7ac687003fca8727df5e27247a679aa9690443cc2a1d8d97ed3580)
  - for some reason I previously used the version of `formula_vaxonly` commented out on [line 252](https://github.com/opensafely/booster-effectiveness/blob/2b38698e4d9d7d9ce62522e4e8937cb3c85e92c6/analysis/model_seqtrialcox.R#L252) in the original booster-effectiveness repo, rather than the vision above on [lines 245-250](https://github.com/opensafely/booster-effectiveness/blob/2b38698e4d9d7d9ce62522e4e8937cb3c85e92c6/analysis/model_seqtrialcox.R#L245-L250)
  - I've updated `formula_vaxonly` to the latter
  - I reran one model ([job here](https://jobs.opensafely.org/assessing-effectiveness-of-3rd-booster-covid-19-vaccine-doses-in-england/vaccine-effectiveness-3dose/18385/)). Changes were very minor and didn't alter interpretation, but all models should be rerun and manuscript updated for the next submission.
- [analysis/variables_jcvi.py](https://github.com/opensafely/vaccine-effectiveness-3dose/pull/20/files#diff-5691f21ae561277fac0795a2c4b70e2bb15982d6d98d0088a47468d902bc7c29)
  - correct the definition of `chronic_kidney_disease` (note: the study definitions have not been rerun since this correction)
- [manuscript/functions.R](https://github.com/opensafely/vaccine-effectiveness-3dose/pull/20/files#diff-1c458c5b5d94cb261fae671742fc62057202e28d5f10b01416e5320e9b993e43)
  - update "third dose" to "booster dose" - this script is used for post processing results and is not used in the project.yaml
- [report/target-trials.R](https://github.com/opensafely/vaccine-effectiveness-3dose/pull/20/files#diff-0114edf0ddeaa2456d9dbd12111a560943800b9f75dd01f4b7d08c03075806de)
  - this was just some plots for a presentation, can be ignored